### PR TITLE
Add apt as an alias to winget

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -236,6 +236,13 @@ function pkill($name) {
 function pgrep($name) {
         Get-Process $name
 }
+#Add apt to winget 
+function aptfunc {
+    winget
+}
+
+Set-Alias apt aptfunc
+
 
 
 ## Final Line to set prompt


### PR DESCRIPTION
Add apt as an alias to winget.

added 
#Add apt to winget 
function aptfunc {
    winget
}

Set-Alias apt aptfunc

to the alias section to make apt a command for winget