### PR TITLE
Fixed -o to -OutFile command

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -13,7 +13,7 @@ if (!(Test-Path -Path $PROFILE -PathType Leaf)) {
             }
         }
 
-        Invoke-RestMethod https://github.com/ChrisTitusTech/powershell-profile/raw/main/Microsoft.PowerShell_profile.ps1 -o $PROFILE
+        Invoke-RestMethod https://github.com/ChrisTitusTech/powershell-profile/raw/main/Microsoft.PowerShell_profile.ps1 -OutFile $PROFILE
         Write-Host "The profile @ [$PROFILE] has been created."
         write-host "if you want to add any persistent components, please do so at
         [$HOME\Documents\PowerShell\Profile.ps1] as there is an updater in the installed profile 


### PR DESCRIPTION
Tried running the setup.ps1 in a fresh installed Windows 11, but it didn't work, I think now it's fixed.
I recommend checking it yourself as this is my first PR, and I'm still learning how to use GitHub


-Fixed a bug to avoid throwing an error because of Microsoft