### PR TITLE
Add PowerShell Aliases for the Linux commands "head and tail", and a function to upload to Pixeldrain from the terminal.

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -235,6 +235,13 @@ function tail {
   param($Path, $n = 10)
   Get-Content $Path -Tail $n
 }
+function pd ($file) {
+    $response = curl.exe -T "$file" https://pixeldrain.com/api/file/
+    $object = $response | ConvertFrom-Json
+    $id = $object.id
+    $url = "https://pixeldrain.com/u/$id"
+    Write-Output $url
+}
 
 # Import the Chocolatey Profile that contains the necessary code to enable
 # tab-completions to function for `choco`.

--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -192,8 +192,12 @@ function unzip ($file) {
     $fullFile = Get-ChildItem -Path $pwd -Filter .\cove.zip | ForEach-Object { $_.FullName }
     Expand-Archive -Path $fullFile -DestinationPath $pwd
 }
-function ix ($file) {
-    curl.exe -F "f:1=@$file" ix.io
+function hb ($file) {
+    $response = curl.exe -X POST -T "$file" "https://hastebin.skyra.pw/documents"
+    $object = $response | ConvertFrom-Json
+    $key = $object.key
+    $url = "https://hastebin.skyra.pw/$key" 
+    Write-Output $url
 }
 function grep($regex, $dir) {
     if ( $dir ) {

--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -223,6 +223,14 @@ function pkill($name) {
 function pgrep($name) {
     Get-Process $name
 }
+function head {
+  param($Path, $n = 10)
+  Get-Content $Path -Head $n
+}
+function tail {
+  param($Path, $n = 10)
+  Get-Content $Path -Tail $n
+}
 
 # Import the Chocolatey Profile that contains the necessary code to enable
 # tab-completions to function for `choco`.


### PR DESCRIPTION
- The Head and Tail command syntax is the same as Linux
- Replaced ix.io with a public Hastebin instance since ix.io no longer works (Syntax: hb <file-path>)
- Added function to upload files to Pixeldrain from the terminal (Syntax: pd <file-path>)