### PR TITLE
Fix the 'ff' Function Output Duplication Problem

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -102,7 +102,7 @@ function Edit-Profile {
 function touch($file) { "" | Out-File $file -Encoding ASCII }
 function ff($name) {
     Get-ChildItem -recurse -filter "*${name}*" -ErrorAction SilentlyContinue | ForEach-Object {
-        Write-Output "$($_.directory)\$($_)"
+        Write-Output "$($_.FullName)"
     }
 }
 


### PR DESCRIPTION
### Some Background & Explaining the Changes
Noticed something odd in the output of `ff` Function while watching your latest video titled "The Ultimate PowerShell", here's [a link](https://www.youtube.com/watch?v=lePxtkrblRE) to it, where it's showing the File's Folder.. then the Full Name of the File on the Same Line.

Turns out it was doing what I've been expecting in the PowerShell Profile, so I've made it output only the `FullName` of a File(s).