### PR TITLE
Add follow option to tail command

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -190,8 +190,8 @@ function head {
 }
 
 function tail {
-  param($Path, $n = 10)
-  Get-Content $Path -Tail $n
+  param($Path, $n = 10, [switch]$f = $false)
+  Get-Content $Path -Tail $n -Wait:$f
 }
 
 # Quick File Creation


### PR DESCRIPTION
This change adds a follow (`-f`) option to the `tail` command for watching log files, similar to the unix command.