### PR TITLE
Persistent Custom Functions File

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -249,6 +249,16 @@ function cpy { Set-Clipboard $args[0] }
 
 function pst { Get-Clipboard }
 
+# Import External Functions File
+# Any Custom Functions can be placed into $FUNCTIONS located in the same folder as $PROFILE
+$env:DOCUMENTS = [Environment]::GetFolderPath([Environment+SpecialFolder]::MyDocuments)
+$FUNCTIONS = "$env:DOCUMENTS\PowerShell\Additional.Functions.ps1"
+if (-not (Test-Path -Path $FUNCTIONS)) {
+  New-Item -Path $FUNCTIONS -ItemType File
+} else {
+  Import-Module -Force -Name $FUNCTIONS
+}
+
 # Enhanced PowerShell Experience
 Set-PSReadLineOption -Colors @{
     Command = 'Yellow'


### PR DESCRIPTION
I felt it would be more adoptable by users if they could keep all their own custom functions within another file located in the same folder as $PROFILE, which I called $FUNCTIONS. This allows someone to do more personal customization that would otherwise be removed during updates, while also allowing auto-updating to stay. 

- Added an external Functions folder ($FUNCTIONS) to hold functions that users may want to keep between updates to powershell-profile.