### PR TITLE
Added a function to customize theme.

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -256,8 +256,21 @@ Set-PSReadLineOption -Colors @{
     String = 'DarkCyan'
 }
 
+# Get theme from profile.ps1 or use a default theme
+function Get-Theme {
+    if (Test-Path -Path $PROFILE.CurrentUserAllHosts -PathType leaf) {
+        $existingTheme = Select-String -Raw -Path $PROFILE.CurrentUserAllHosts -Pattern "oh-my-posh init pwsh --config"
+        if ($null -ne $existingTheme) {
+            Invoke-Expression $existingTheme
+            return
+        }
+    } else {
+        oh-my-posh init pwsh --config https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/cobalt2.omp.json | Invoke-Expression
+    }
+}
+
 ## Final Line to set prompt
-oh-my-posh init pwsh --config https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/cobalt2.omp.json | Invoke-Expression
+Get-Theme
 if (Get-Command zoxide -ErrorAction SilentlyContinue) {
     Invoke-Expression (& { (zoxide init powershell | Out-String) })
 } else {


### PR DESCRIPTION
Although functions can be added in the Profile.ps1 file, Oh My Posh themes added there won't be used. I added a function to check if a theme has been added in Profile.ps1, and if there is, set it to be the theme used. Otherwise the default theme from before gets loaded as usual. Fixes https://github.com/ChrisTitusTech/powershell-profile/issues/52

My first pull request went a bit wrong (by my own doing) hence the reason for this second pull request!