### PR TITLE
Update documentation to clarify how to make changes and customize the profile

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -1,6 +1,21 @@
 ### PowerShell Profile Refactor
 ### Version 1.03 - Refactored
 
+#################################################################################################################################
+############                                                                                                         ############
+############                                          !!!   WARNING:   !!!                                           ############
+############                                                                                                         ############
+############                DO NOT MODIFY THIS FILE. THIS FILE IS HASHED AND UPDATED AUTOMATICALLY.                  ############
+############                    ANY CHANGES MADE TO THIS FILE WILL BE OVERWRITTEN BY COMMITS TO                      ############
+############                       https://github.com/ChrisTitusTech/powershell-profile.git.                         ############
+############                                                                                                         ############
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!#
+############                                                                                                         ############
+############                      IF YOU WANT TO MAKE CHANGES, USE THE Edit-Profile FUNCTION                         ############
+############                              AND SAVE YOUR CHANGES IN THE FILE CREATED.                                 ############
+############                                                                                                         ############
+#################################################################################################################################
+
 # Initial GitHub.com connectivity check with 1 second timeout
 $canConnectToGitHub = Test-Connection github.com -Count 1 -Quiet -TimeoutSeconds 1
 

--- a/README.md
+++ b/README.md
@@ -17,4 +17,10 @@ After running the script, you'll find a downloaded `cove.zip` file in the folder
 1. Extract the `cove.zip` file.
 2. Locate and install the nerd fonts.
 
+## Customize this profile
+
+**Do not make any changes to the `Microsoft.PowerShell_profile.ps1` file**, since it's hashed and automatically overwritten by any commits to this repository.
+
+After the profile is installed and active, run the `Edit-Profile` function to create a separate profile file for your current user. Make any changes and customizations in this new file named `profile.ps1`.
+
 Now, enjoy your enhanced and stylish PowerShell experience! 🚀

--- a/setup.ps1
+++ b/setup.ps1
@@ -39,7 +39,7 @@ if (!(Test-Path -Path $PROFILE -PathType Leaf)) {
 
         Invoke-RestMethod https://github.com/ChrisTitusTech/powershell-profile/raw/main/Microsoft.PowerShell_profile.ps1 -OutFile $PROFILE
         Write-Host "The profile @ [$PROFILE] has been created."
-        Write-Host "If you want to add any persistent components, please do so at [$profilePath\Profile.ps1] as there is an updater in the installed profile which uses the hash to update the profile and will lead to loss of changes"
+        Write-Host "If you want to make any personal changes or customizations, please do so at [$profilePath\Profile.ps1] as there is an updater in the installed profile which uses the hash to update the profile and will lead to loss of changes"
     }
     catch {
         Write-Error "Failed to create or update the profile. Error: $_"


### PR DESCRIPTION
There's a warning comment in Microsoft.PowerShell_profile.ps1 that lets the user know that the file should not be modified.

In README, I added a section detailing how to make customizations and personal changes to the profile using the Edit-Profile function to create a profile for the current user.

I also updated the message printed in setup.ps1 to clarify the same message, all personal changes and customizations should be made in the separate profile for the current user.

