### PR TITLE
Update Readme to provide an easier method of installing new fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,35 @@ irm "https://github.com/ChrisTitusTech/powershell-profile/raw/main/setup.ps1" | 
 
 ## 🛠️ Fix the Missing Font
 
-After running the script, you'll find a downloaded `cove.zip` file in the folder you executed the script from. Follow these steps to install the required nerd fonts:
+After running the script, you'll have two options for installing a font patched to support icons in PowerShell:
+
+### 1) You will find a downloaded `cove.zip` file in the folder you executed the script from. Follow these steps to install the patched `Caskaydia Cove` nerd font family:
 
 1. Extract the `cove.zip` file.
 2. Locate and install the nerd fonts.
 
+### 2) With `oh-my-posh` (loaded automatically through the PowerShell profile script hosted on this repo):
+1. Run the command `oh-my-posh font install`
+2. A list of Nerd Fonts will appear like so:
+<pre>
+PS> oh-my-posh font install
+
+   Select font
+
+  > 0xProto
+    3270
+    Agave
+    AnonymousPro
+    Arimo
+    AurulentSansMono
+    BigBlueTerminal
+    BitstreamVeraSansMono
+
+    •••••••••
+    ↑/k up • ↓/j down • q quit • ? more</pre>
+3. With the up/down arrow keys, select the font you would like to install and press <kbd>ENTER</kbd>
+4. DONE!
+   
 ## Customize this profile
 
 **Do not make any changes to the `Microsoft.PowerShell_profile.ps1` file**, since it's hashed and automatically overwritten by any commits to this repository.


### PR DESCRIPTION
Since this Profile installs oh-my-posh already, why not just use 
```
oh-my-posh font install
``` 
as a much more convenient method to download/install a patched font? **Note** that CaskaydiaCove is even available as an option using this method.  

Running that command, the user is presented with the following interactive menu which does all the work of downloading, installing and selecting the font to be used by PowerShell / Terminal:  

<pre> oh-my-posh font install

    Select font

  > 0xProto
    3270
    Agave
    AnonymousPro
    Arimo
    AurulentSansMono
    BigBlueTerminal
    BitstreamVeraSansMono

    •••••••••
    ↑/k up • ↓/j down • q quit • ? more </pre>