### PR TITLE
Add generic function to install Nerd Fonts

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -16,6 +16,48 @@ function Test-InternetConnection {
     }
 }
 
+# Function to install Nerd Fonts
+function Install-NerdFonts {
+    param (
+        [string]$FontName = "CascadiaCode",
+        [string]$FontDisplayName = "CaskaydiaCove NF",
+        [string]$Version = "3.2.1"
+    )
+
+    try {
+        [void] [System.Reflection.Assembly]::LoadWithPartialName("System.Drawing")
+        $fontFamilies = (New-Object System.Drawing.Text.InstalledFontCollection).Families.Name
+        if ($fontFamilies -notcontains "${FontDisplayName}") {
+            $fontZipUrl = "https://github.com/ryanoasis/nerd-fonts/releases/download/v${Version}/${FontName}.zip"
+            $zipFilePath = "$env:TEMP\${FontName}.zip"
+            $extractPath = "$env:TEMP\${FontName}"
+
+            $webClient = New-Object System.Net.WebClient
+            $webClient.DownloadFileAsync((New-Object System.Uri($fontZipUrl)), $zipFilePath)
+
+            while ($webClient.IsBusy) {
+                Start-Sleep -Seconds 2
+            }
+
+            Expand-Archive -Path $zipFilePath -DestinationPath $extractPath -Force
+            $destination = (New-Object -ComObject Shell.Application).Namespace(0x14)
+            Get-ChildItem -Path $extractPath -Recurse -Filter "*.ttf" | ForEach-Object {
+                If (-not(Test-Path "C:\Windows\Fonts\$($_.Name)")) {
+                    $destination.CopyHere($_.FullName, 0x10)
+                }
+            }
+
+            Remove-Item -Path $extractPath -Recurse -Force
+            Remove-Item -Path $zipFilePath -Force
+        } else {
+            Write-Host "Font ${FontDisplayName} already installed"
+        }
+    }
+    catch {
+        Write-Error "Failed to download or install ${FontDisplayName} font. Error: $_"
+    }
+}
+
 # Check for internet connectivity before proceeding
 if (-not (Test-InternetConnection)) {
     break
@@ -26,7 +68,7 @@ if (!(Test-Path -Path $PROFILE -PathType Leaf)) {
     try {
         # Detect Version of PowerShell & Create Profile directories if they do not exist.
         $profilePath = ""
-        if ($PSVersionTable.PSEdition -eq "Core") { 
+        if ($PSVersionTable.PSEdition -eq "Core") {
             $profilePath = "$env:userprofile\Documents\Powershell"
         }
         elseif ($PSVersionTable.PSEdition -eq "Desktop") {
@@ -66,33 +108,7 @@ catch {
 }
 
 # Font Install
-try {
-    [void] [System.Reflection.Assembly]::LoadWithPartialName("System.Drawing")
-    $fontFamilies = (New-Object System.Drawing.Text.InstalledFontCollection).Families.Name
-
-    if ($fontFamilies -notcontains "CaskaydiaCove NF") {
-        $webClient = New-Object System.Net.WebClient
-        $webClient.DownloadFileAsync((New-Object System.Uri("https://github.com/ryanoasis/nerd-fonts/releases/download/v3.2.1/CascadiaCode.zip")), ".\CascadiaCode.zip")
-        
-        while ($webClient.IsBusy) {
-            Start-Sleep -Seconds 2
-        }
-
-        Expand-Archive -Path ".\CascadiaCode.zip" -DestinationPath ".\CascadiaCode" -Force
-        $destination = (New-Object -ComObject Shell.Application).Namespace(0x14)
-        Get-ChildItem -Path ".\CascadiaCode" -Recurse -Filter "*.ttf" | ForEach-Object {
-            If (-not(Test-Path "C:\Windows\Fonts\$($_.Name)")) {        
-                $destination.CopyHere($_.FullName, 0x10)
-            }
-        }
-
-        Remove-Item -Path ".\CascadiaCode" -Recurse -Force
-        Remove-Item -Path ".\CascadiaCode.zip" -Force
-    }
-}
-catch {
-    Write-Error "Failed to download or install the Cascadia Code font. Error: $_"
-}
+Install-NerdFonts -FontName "CascadiaCode" -FontDisplayName "CaskaydiaCove NF"
 
 # Final check and message to the user
 if ((Test-Path -Path $PROFILE) -and (winget list --name "OhMyPosh" -e) -and ($fontFamilies -contains "CaskaydiaCove NF")) {


### PR DESCRIPTION
I use code from here to write my own setup scripts, so I thought I might share what I added.

---

I added a generic function to install Nerd Fonts. It allows users to easily choose which font to install. The behavior is basically untouched; I just moved the downloaded font files to ` env:$TEMP ` and added a message if the installation is skipped (when the fonts are already installed).