### PR TITLE
Added PS5 Compatibility

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -16,6 +16,8 @@
 ############                                                                                                         ############
 #################################################################################################################################
 
+Import-Module PSReadLine
+
 #opt-out of telemetry before doing anything, only if PowerShell is run as admin
 if ([bool]([System.Security.Principal.WindowsIdentity]::GetCurrent()).IsSystem) {
     [System.Environment]::SetEnvironmentVariable('POWERSHELL_TELEMETRY_OPTOUT', 'true', [System.EnvironmentVariableTarget]::Machine)

--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -16,8 +16,6 @@
 ############                                                                                                         ############
 #################################################################################################################################
 
-Import-Module PSReadLine
-
 #opt-out of telemetry before doing anything, only if PowerShell is run as admin
 if ([bool]([System.Security.Principal.WindowsIdentity]::GetCurrent()).IsSystem) {
     [System.Environment]::SetEnvironmentVariable('POWERSHELL_TELEMETRY_OPTOUT', 'true', [System.EnvironmentVariableTarget]::Machine)

--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -22,8 +22,7 @@ if ([bool]([System.Security.Principal.WindowsIdentity]::GetCurrent()).IsSystem) 
 }
 
 # Initial GitHub.com connectivity check with 1 second timeout
-$pingResult = Test-Connection github.com -Count 1 -ErrorAction SilentlyContinue
-$canConnectToGitHub = $pingResult.StatusCode -eq 0
+$canConnectToGitHub = $null -ne (ping github.com -n 1 -w 1000 | Select-String "Reply from")
 
 # Import Modules and External Profiles
 # Ensure Terminal-Icons module is installed before importing
@@ -299,15 +298,17 @@ Set-PSReadLineOption -Colors @{
     String = 'DarkCyan'
 }
 
-$PSROptions = @{
-    ContinuationPrompt = '  '
-    Colors             = @{
-    Parameter          = $PSStyle.Foreground.Magenta
-    Selection          = $PSStyle.Background.Black
-    InLinePrediction   = $PSStyle.Foreground.BrightYellow + $PSStyle.Background.BrightBlack
+if ($PSVersionTable.PSVersion.Major -ge 7) {
+    $PSROptions = @{
+        ContinuationPrompt = '  '
+        Colors             = @{
+            Parameter          = $PSStyle.Foreground.Magenta
+            Selection          = $PSStyle.Background.Black
+            InLinePrediction   = $PSStyle.Foreground.BrightYellow + $PSStyle.Background.BrightBlack
+        }
     }
+    Set-PSReadLineOption @PSROptions
 }
-Set-PSReadLineOption @PSROptions
 Set-PSReadLineKeyHandler -Chord 'Ctrl+f' -Function ForwardWord
 Set-PSReadLineKeyHandler -Chord 'Enter' -Function ValidateAndAcceptLine
 

--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -22,7 +22,8 @@ if ([bool]([System.Security.Principal.WindowsIdentity]::GetCurrent()).IsSystem) 
 }
 
 # Initial GitHub.com connectivity check with 1 second timeout
-$canConnectToGitHub = Test-Connection github.com -Count 1 -Quiet -TimeoutSeconds 1
+$pingResult = Test-Connection github.com -Count 1 -ErrorAction SilentlyContinue
+$canConnectToGitHub = $pingResult.StatusCode -eq 0
 
 # Import Modules and External Profiles
 # Ensure Terminal-Icons module is installed before importing


### PR DESCRIPTION
When using with PowerShell 5, I get always an error bc `-TimeoutSeconds 1` does not exist there.
So I replaces it with something it does understand.

Set & run `Set-PSReadLineOption @PSROptions` only if ps7 is used. Module seems to be available for ps5, but does not work.