### PR TITLE
fix(): remove duplicate call to Set-PSReadLineOption

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -292,18 +292,14 @@ function cpy { Set-Clipboard $args[0] }
 function pst { Get-Clipboard }
 
 # Enhanced PowerShell Experience
-Set-PSReadLineOption -Colors @{
-    Command = 'Yellow'
-    Parameter = 'Green'
-    String = 'DarkCyan'
-}
-
 $PSROptions = @{
     ContinuationPrompt = '  '
     Colors             = @{
-    Parameter          = $PSStyle.Foreground.Magenta
-    Selection          = $PSStyle.Background.Black
-    InLinePrediction   = $PSStyle.Foreground.BrightYellow + $PSStyle.Background.BrightBlack
+		Command            = $PSStyle.Foreground.Yellow
+    	Parameter          = $PSStyle.Foreground.Green
+    	String 			   = $PSStyle.Foreground.Cyan
+		Selection          = $PSStyle.Background.Black
+    	InLinePrediction   = $PSStyle.Foreground.BrightYellow + $PSStyle.Background.BrightBlack
     }
 }
 Set-PSReadLineOption @PSROptions


### PR DESCRIPTION
Set-PSReadLineOption is getting called twice so I removed the first call and merged the colour table of both into one.