### PR TITLE
fix(): ep as alias for Edit-Profile

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -116,9 +116,12 @@ $EDITOR = if (Test-CommandExists nvim) { 'nvim' }
           else { 'notepad' }
 Set-Alias -Name vim -Value $EDITOR
 
+# Quick Access to Editing the Profile
 function Edit-Profile {
     vim $PROFILE.CurrentUserAllHosts
 }
+Set-Alias -Name ep -Value Edit-Profile
+
 function touch($file) { "" | Out-File $file -Encoding ASCII }
 function ff($name) {
     Get-ChildItem -recurse -filter "*${name}*" -ErrorAction SilentlyContinue | ForEach-Object {
@@ -243,9 +246,6 @@ function mkcd { param($dir) mkdir $dir -Force; Set-Location $dir }
 function docs { Set-Location -Path $HOME\Documents }
 
 function dtop { Set-Location -Path $HOME\Desktop }
-
-# Quick Access to Editing the Profile
-function ep { vim $PROFILE }
 
 # Simplified Process Management
 function k9 { Stop-Process -Name $args[0] }


### PR DESCRIPTION
ep does not seem to work for me, however, Edit-Profile does. Also, it is cleaner to have one implementation of the Edit-Profile func and just set ep as an alias for it.