### PR TITLE
Add customization possibility

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -438,4 +438,9 @@ pst - Retrieves text from the clipboard.
 Use 'Show-Help' to display this help message.
 "@
 }
+
+if (Test-Path "$PSScriptRoot\CTTcustom.ps1") {
+    Invoke-Expression -Command "& `"$PSScriptRoot\CTTcustom.ps1`""
+}
+
 Write-Host "Use 'Show-Help' to display help"


### PR DESCRIPTION
User can create "CTTcustom.ps1" file in same directory as the profile which will be executed at the end of the profile to customize it to his own liking, without his preferences being overwritten. If the file does not exist it skips this part.