### PR TITLE
adding default to Get-Theme so even if you have a leaf profile

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -328,6 +328,7 @@ function Get-Theme {
             Invoke-Expression $existingTheme
             return
         }
+        oh-my-posh init pwsh --config https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/cobalt2.omp.json | Invoke-Expression
     } else {
         oh-my-posh init pwsh --config https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/cobalt2.omp.json | Invoke-Expression
     }


### PR DESCRIPTION
Adding a default to Get-Theme so even if you have a leaf profile, it will set the default if the leaf profile doesn't have another oh-my-posh command. resolves #104 