### PR TITLE
Fix admin elevation arguments

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -137,7 +137,7 @@ function winutil {
 # System Utilities
 function admin {
     if ($args.Count -gt 0) {
-        $argList = "& '$args'"
+        $argList = $args -join ' '
         Start-Process wt -Verb runAs -ArgumentList "pwsh.exe -NoExit -Command $argList"
     } else {
         Start-Process wt -Verb runAs


### PR DESCRIPTION
When using admin such as `admin ls`, it works fine.
However, if passing in multiple arguments such as `admin sfc /scannow`, it doesn't work.
This pull request should fix this.