### PR TITLE
Removed warning when update is skipped.

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -87,9 +87,7 @@ if (-not $debug -and `
     $currentTime = Get-Date -Format 'yyyy-MM-dd'
     $currentTime | Out-File -FilePath $timeFilePath
 
-} elseif (-not $debug) {
-    Write-Warning "Profile update skipped. Last update check was within the last $updateInterval day(s)."
-} else {
+} elseif ($debug) {
     Write-Warning "Skipping profile update check in debug mode"
 }
 
@@ -127,9 +125,7 @@ if (-not $debug -and `
     Update-PowerShell
     $currentTime = Get-Date -Format 'yyyy-MM-dd'
     $currentTime | Out-File -FilePath $timeFilePath
-} elseif (-not $debug) {
-    Write-Warning "PowerShell update skipped. Last update check was within the last $updateInterval day(s)."
-} else {
+} elseif ($debug) {
     Write-Warning "Skipping PowerShell update in debug mode"
 }
 


### PR DESCRIPTION
In order to reduce the messages every time a terminal is opened, I have removed two of the update warnings that were added with the latest merge that introduces the feature to delay updates every 7 days. 
Closes #130. 