### PR TITLE
Fix/timepath var

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -4,7 +4,7 @@
 $debug = $false
 
 # Define the path to the file that stores the last execution time
-$timeFilePath = "$env:USERPROFILE\Documents\PowerShell\LastExecutionTime.txt"
+$timeFilePath = [Environment]::GetFolderPath("MyDocuments") + "\PowerShell\LastExecutionTime.txt"
 
 # Define the update interval in days, set to -1 to always check
 $updateInterval = 7


### PR DESCRIPTION
Hi,

I encountered this error because I have the "My Documents" folder on another location.

![error_pwsh](https://github.com/user-attachments/assets/ae346a3d-eee0-48c0-9443-80ef6e9aeb99)

So I replaced the `$env:USERPROFILE` with `[Environment]::GetFolderPath("MyDocuments")` as the goal is to get this specific folder to reach the LastExecutionTime.txt file.

closes #131 