### PR TITLE
Fix `la` and `ll` functions so they do what the help says

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -403,8 +403,8 @@ function dtop {
 function k9 { Stop-Process -Name $args[0] }
 
 # Enhanced Listing
-function la { Get-ChildItem -Path . -Force | Format-Table -AutoSize }
-function ll { Get-ChildItem -Path . -Force -Hidden | Format-Table -AutoSize }
+function la { Get-ChildItem | Format-Table -AutoSize }
+function ll { Get-ChildItem -Force | Format-Table -AutoSize }
 
 # Git Shortcuts
 function gs { git status }


### PR DESCRIPTION
This is a simple fix on `la` and `ll` functions so they behave as described in `Show-Help`:
* `la` function was listing all files, including hidden ones, which should be performed by `ll`. Now, it shows only regular files;
* `ll` function was showing only hidden files. Now it shows all files, including hidden ones, in a directory;
* Removed the redundant `-Path .` attribute since `Get-ChildItem` uses the current path by default.

Closes #118 