### PR TITLE
Replaced the command "net statistics" with "Get-Uptime"

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -231,7 +231,7 @@ function uptime {
             # reformat lastBoot
             $lastBoot = $bootTime.ToString("$dateFormat $timeFormat")
         } else {
-			# the Get-Uptime cmdlet was introduced in PowerShell 6.0
+	    # the Get-Uptime cmdlet was introduced in PowerShell 6.0
             $lastBoot = (Get-Uptime -Since).ToString("$dateFormat $timeFormat")			
             $bootTime = [System.DateTime]::ParseExact($lastBoot, "$dateFormat $timeFormat", [System.Globalization.CultureInfo]::InvariantCulture)
         }

--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -231,7 +231,7 @@ function uptime {
             # reformat lastBoot
             $lastBoot = $bootTime.ToString("$dateFormat $timeFormat")
         } else {
-	    # the Get-Uptime cmdlet was introduced in PowerShell 6.0
+            # the Get-Uptime cmdlet was introduced in PowerShell 6.0
             $lastBoot = (Get-Uptime -Since).ToString("$dateFormat $timeFormat")			
             $bootTime = [System.DateTime]::ParseExact($lastBoot, "$dateFormat $timeFormat", [System.Globalization.CultureInfo]::InvariantCulture)
         }

--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -231,7 +231,8 @@ function uptime {
             # reformat lastBoot
             $lastBoot = $bootTime.ToString("$dateFormat $timeFormat")
         } else {
-            $lastBoot = net statistics workstation | Select-String "since" | ForEach-Object { $_.ToString().Replace('Statistics since ', '') }
+			# the Get-Uptime cmdlet was introduced in PowerShell 6.0
+            $lastBoot = (Get-Uptime -Since).ToString("$dateFormat $timeFormat")			
             $bootTime = [System.DateTime]::ParseExact($lastBoot, "$dateFormat $timeFormat", [System.Globalization.CultureInfo]::InvariantCulture)
         }
 


### PR DESCRIPTION
Replaced the command `net statistics workstation ...` with `Get-Uptime` available since PowerShell ver. 6.
The reason is that the output of the command `net statistics` depends on the language of the operating system and it is not possible to execute: `net statistics workstation | Select-String "since"`.

In Italy for example
the output of the command is:
...
Statistiche dal 18/04/2025 08:48:09
...

<img width="865" alt="net_statistics" src="https://github.com/user-attachments/assets/9f10a82f-9350-4fab-9f71-a8b7ae26a0dd" />
