### PR TITLE
Save oldprofile.ps1 in $PROFILE directory, avoid Alias conflicts with gp, and add gpull

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -394,7 +394,9 @@ function ga { git add . }
 
 function gc { param($m) git commit -m "$m" }
 
-function gp { git push }
+function gpush { git push }
+
+function gpull { git pull }
 
 function g { __zoxide_z github }
 

--- a/setup.ps1
+++ b/setup.ps1
@@ -89,13 +89,15 @@ if (!(Test-Path -Path $PROFILE -PathType Leaf)) {
 }
 else {
     try {
-        Get-Item -Path $PROFILE | Move-Item -Destination "oldprofile.ps1" -Force
+        $backupPath = Join-Path (Split-Path $PROFILE) "oldprofile.ps1"
+        Move-Item -Path $PROFILE -Destination $backupPath -Force
         Invoke-RestMethod https://github.com/ChrisTitusTech/powershell-profile/raw/main/Microsoft.PowerShell_profile.ps1 -OutFile $PROFILE
-        Write-Host "The profile @ [$PROFILE] has been created and old profile removed."
-        Write-Host "Please back up any persistent components of your old profile to [$HOME\Documents\PowerShell\Profile.ps1] as there is an updater in the installed profile which uses the hash to update the profile and will lead to loss of changes"
+        Write-Host "✅ PowerShell profile at [$PROFILE] has been updated."
+        Write-Host "📦 Your old profile has been backed up to [$backupPath]"
+        Write-Host "⚠️ NOTE: Please back up any persistent components of your old profile to [$HOME\Documents\PowerShell\Profile.ps1] as there is an updater in the installed profile which uses the hash to update the profile and will lead to loss of changes"
     }
     catch {
-        Write-Error "Failed to backup and update the profile. Error: $_"
+        Write-Error "❌ Failed to backup and update the profile. Error: $_"
     }
 }
 


### PR DESCRIPTION
## Previous Behaviour:
When updating the PowerShell profile, the script backed up the old profile using this command:
```
Get-Item -Path $PROFILE | Move-Item -Destination "oldprofile.ps1" -Force
```
This moves the current profile to a file named oldprofile.ps1 in the current working directory, where PowerShell was open. This leads to confusion and makes it hard for users to locate their previous customisations.

## New Behaviour:
Now, the old profile is saved in the same directory as the PowerShell profile itself, using:
```
$backupPath = Join-Path (Split-Path $PROFILE) "oldprofile.ps1"
Move-Item -Path $PROFILE -Destination $backupPath -Force
```
This ensures the backup is stored alongside the main profile file, making it easier to find.

The user message is also updated to clearly mention where the backup is and that any persistent changes should go into a Profile.ps1 file, not the auto-updated profile.

---
## Additional Changes:

- Renamed the custom PowerShell function for git push from gp to gpush to avoid conflict with the built-in gp alias for Get-ItemProperty.
- Added a new gpull function for git pull.

[Powershell Documentation](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/get-itemproperty?view=powershell-7.5#notes)
![image](https://github.com/user-attachments/assets/647ea6cf-e332-4204-b8c7-7df5e4598f36)