### PR TITLE
Fixes to that if there is an Get-Theme_Override then call that functi…

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -608,7 +608,11 @@ $scriptblock = {
 }
 Register-ArgumentCompleter -Native -CommandName dotnet -ScriptBlock $scriptblock
 
-oh-my-posh init pwsh --config https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/cobalt2.omp.json | Invoke-Expression
+if (Get-Command -Name "Get-Theme_Override" -ErrorAction SilentlyContinue){
+    Get-Theme_Override;
+} else {
+    oh-my-posh init pwsh --config https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/cobalt2.omp.json | Invoke-Expression
+}
 
 if (Get-Command zoxide -ErrorAction SilentlyContinue) {
     Invoke-Expression (& { (zoxide init --cmd z powershell | Out-String) })


### PR DESCRIPTION
Fixes so that if there is an Get-Theme_Override then call that function to fix oh-my-posh problems and keep zoxide working. 

Example function:

function Get-Theme_Override
{
    Invoke-Expression (& { (oh-my-posh init pwsh --config c:\ws\oh-my-posh\pmc.chips.omp.json | Out-String) })
}