### PR TITLE
Optimize for virtual terminal

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -542,11 +542,17 @@ $PSReadLineOptions = @{
         Keyword = '#8367c7'  # Violet (pastel)
         Error = '#FF6347'  # Tomato (keeping it close to red for visibility)
     }
-    PredictionSource = 'History'
-    PredictionViewStyle = 'ListView'
     BellStyle = 'None'
 }
 Set-PSReadLineOption @PSReadLineOptions
+
+# Try to enable prediction features if supported
+try {
+    Set-PSReadLineOption -PredictionSource History -ErrorAction Stop
+    Set-PSReadLineOption -PredictionViewStyle ListView -ErrorAction Stop
+} catch {
+    # Silently continue if prediction features are not supported
+}
 
 # Custom key handlers
 Set-PSReadLineKeyHandler -Key UpArrow -Function HistorySearchBackward
@@ -575,7 +581,11 @@ function Set-PredictionSource {
         Set-PredictionSource_Override;
     } else {
 	# Improved prediction settings
-	Set-PSReadLineOption -PredictionSource HistoryAndPlugin
+	try {
+	    Set-PSReadLineOption -PredictionSource HistoryAndPlugin -ErrorAction Stop
+	} catch {
+	    # Silently continue if prediction features are not supported
+	}
 	Set-PSReadLineOption -MaximumHistoryCount 10000
     }
 }


### PR DESCRIPTION
No more this
```
Set-PSReadLineOption: C:\Users\wtf\Documents\PowerShell\Microsoft.PowerShell_profile.ps1:549
Line |
 549 |  Set-PSReadLineOption @PSReadLineOptions
     |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | The predictive suggestion feature cannot be enabled because the console output doesn't support virtual terminal
     | processing or it's redirected.
Set-PSReadLineOption: C:\Users\wtf\Documents\PowerShell\Microsoft.PowerShell_profile.ps1:578
Line |
 578 |      Set-PSReadLineOption -PredictionSource HistoryAndPlugin
     |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | The predictive suggestion feature cannot be enabled because the console output doesn't support virtual terminal
     | processing or it's redirected.
Use 'Show-Help' to display help
```