### PR TITLE
Change lastExec variable to Nullable[datetime]

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -139,7 +139,7 @@ if (Test-Path($ChocolateyProfile)) {
 
 # Safely read and parse the last execution date once to avoid exceptions when the file is missing or empty
 $lastExecRaw = if (Test-Path $timeFilePath) { (Get-Content -Path $timeFilePath -Raw).Trim() } else { $null }
-[datetime]$lastExec = $null
+[Nullable[datetime]]$lastExec = $null
 if (-not [string]::IsNullOrWhiteSpace($lastExecRaw)) {
     [datetime]$parsed = [datetime]::MinValue
     if ([datetime]::TryParseExact($lastExecRaw, 'yyyy-MM-dd', $null, [System.Globalization.DateTimeStyles]::None, [ref]$parsed)) {


### PR DESCRIPTION
* Switch to null semantics to avoid DateTime conversion errors

Should be a little fix...
here what happens with null semantic:
<img width="481" height="313" alt="grafik" src="https://github.com/user-attachments/assets/17860c52-0cd9-40e5-be4f-03c62853290d" />
and that happens with `[datetime]$lastExec = $null`
<img width="789" height="426" alt="grafik" src="https://github.com/user-attachments/assets/395ba32f-bd39-40e5-a587-fc41da2413b1" />
