### PR TITLE
Add conditional display for Show-Help message

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -22,6 +22,7 @@ $debug = $false
 ############                      $EDITOR_Override                                                                   ############
 ############                      $debug_Override                                                                    ############
 ############                      $repo_root_Override  [To point to a fork, for example]                             ############
+############                      $show_help_Override  [display Show-Help on PowerShell launch]                      ############
 ############                      $timeFilePath_Override                                                             ############
 ############                      $updateInterval_Override                                                           ############
 ############                                                                                                         ############
@@ -758,4 +759,6 @@ if (Test-Path "$PSScriptRoot\CTTcustom.ps1") {
     Invoke-Expression -Command "& `"$PSScriptRoot\CTTcustom.ps1`""
 }
 
-Write-Host "$($PSStyle.Foreground.Yellow)Use 'Show-Help' to display help$($PSStyle.Reset)"
+if (-not $show_help_Override) {
+    Write-Host "$($PSStyle.Foreground.Yellow)Use 'Show-Help' to display help$($PSStyle.Reset)"
+}


### PR DESCRIPTION
Add possibility to suppress Show-Help message display on PowerShell launch when show_help_Override variable defined in profile.ps1.

Cheers,