### PR TITLE
Change invocation method for CTTcustom.ps1

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -755,7 +755,7 @@ Use '$($PSStyle.Foreground.Magenta)Show-Help$($PSStyle.Reset)' to display this h
 }
 
 if (Test-Path "$PSScriptRoot\CTTcustom.ps1") {
-    Invoke-Expression -Command "& `"$PSScriptRoot\CTTcustom.ps1`""
+    . "$PSScriptRoot\CTTcustom.ps1"
 }
 
 Write-Host "$($PSStyle.Foreground.Yellow)Use 'Show-Help' to display help$($PSStyle.Reset)"


### PR DESCRIPTION
The `&` (call operator) executes a script in a child scope, meaning any functions defined within `CTTcustom.ps1` are not exposed to your main PowerShell session. This change will ensure that `CTTcustom.ps1` is loaded into the current PowerShell session's scope, making any functions defined in it accessible.