### PR TITLE
Fix uptime function to use Get-CimInstance

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -90,7 +90,7 @@ function k9 ($Name) {
 
 # System Utilities
 function uptime {
-    (Get-Date) - (Get-CimClass -ClassName Win32_OperatingSystem).LastBootUpTime | Select-Object Days, Hours, Minutes, Seconds
+    (Get-Date) - (Get-CimInstance -ClassName Win32_OperatingSystem).LastBootUpTime | Select-Object Days, Hours, Minutes, Seconds
 }
 
 function winutil {


### PR DESCRIPTION
### Details

## Type Of Change
- [X] Bug fix
- [ ] New feature

## Changes
Changed uptime function to use Get-CimInstance

## Description
uptime cause error in pwsh 7.6.1
Correct way is to use Get-CimInstance

related to issue: [https://github.com/ChrisTitusTech/powershell-profile/issues/195](https://github.com/ChrisTitusTech/powershell-profile/issues/195)