### PR TITLE
feat: add argument forwarding to winutil commands

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -94,11 +94,11 @@ function uptime {
 }
 
 function winutil {
-    Invoke-RestMethod https://christitus.com/win | Invoke-Expression
+    & ([ScriptBlock]::Create((Invoke-RestMethod https://christitus.com/win))) @args
 }
 
 function winutildev {
-    Invoke-RestMethod https://christitus.com/windev | Invoke-Expression
+    & ([ScriptBlock]::Create((Invoke-RestMethod https://christitus.com/windev))) @args
 }
 
 # Git Shortcuts


### PR DESCRIPTION
## Description
Updates the existing `winutil` and `winutildev` profile functions to support proper argument forwarding (e.g., `winutil -Preset Standard -Noui`).

### Key Improvements:
1. **Zero Bloat One-Liners:** Uses direct, clean, and inline compilation/execution to avoid polluting the global namespace with helper functions.
2. **Argument Splatting:** Employs native `@args` splatting to seamlessly unpack and bind named parameters/switches (like `-Config` or `-Noui`) perfectly, fully supported since PowerShell 2.0.

### Build & Release Note:
* **Local Verification:** Fully verified locally using the latest compiled WinUtil script containing the new automation parameters.
* **Online Builds:** Note that since live online builds (`christitus.com/win` and `windev`) are cached from commits prior to the automation changes, they currently ignore parameters and launch the GUI. Once a new release is pushed online, this profile update will work seamlessly.

### Usage Example:
```powershell
winutil -Preset Standard -Noui
winutildev -Config "C:\path\to\config.json"
```
