### PR TITLE
fix/201-restore-theme-override

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -1,7 +1,5 @@
 ### Chris Titus Tech's PowerShell profile
 
-oh-my-posh init pwsh --config $Home\cobalt2.omp.json | Invoke-Expression
-zoxide init --cmd z powershell | Out-String | Invoke-Expression
 Import-Module -Name Terminal-Icons
 
 Write-Host "Use 'Show-Help' to list all available functions" -ForegroundColor Yellow
@@ -188,3 +186,7 @@ ${dim}────────────────────────�
 ${dim}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${reset}
 "@
 }
+
+# init commands should be at the end of the profile
+oh-my-posh init pwsh --config $env:POSH_THEME | Invoke-Expression
+zoxide init --cmd z powershell | Out-String | Invoke-Expression

--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -188,5 +188,5 @@ ${dim}━━━━━━━━━━━━━━━━━━━━━━━━�
 }
 
 # init commands should be at the end of the profile
-oh-my-posh init pwsh --config $env:POSH_THEME | Invoke-Expression
-zoxide init --cmd z powershell | Out-String | Invoke-Expression
+Invoke-Expression (& { (oh-my-posh init pwsh --config $env:POSH_THEME | Out-String) })
+Invoke-Expression (& { (zoxide init --cmd z powershell | Out-String) })


### PR DESCRIPTION
## Type Of Change
- [X] Bug fix
- [ ] New feature

## Changes
Fixed so that oh-my-posh uses **POSH_THEME** as config file

You need to add this line to your **profile.ps1**
`$env:POSH_THEME = "powerlevel10k_rainbow.omp.json"`


Fixes #201 