### PR TITLE
set vim editor alias only if vim not present

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -289,8 +289,12 @@ function Resolve-Editor {
 Initialize-OptionalModule
 
 $isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+if (Get-Alias vim -ErrorAction SilentlyContinue) {
+    Remove-Alias -Name vim
+}
 $EDITOR = Resolve-Editor
-if ($EDITOR -ne "vim") {
+if (-not (Get-Command -Name vim -CommandType Application -ErrorAction SilentlyContinue)) {
     Set-Alias -Name vim -Value $EDITOR -Force
 }
 

--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -290,7 +290,9 @@ Initialize-OptionalModule
 
 $isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
 $EDITOR = Resolve-Editor
-Set-Alias -Name vim -Value $EDITOR -Force
+if ($EDITOR -ne "vim") {
+    Set-Alias -Name vim -Value $EDITOR -Force
+}
 
 if ($isInteractiveShell) {
     try {


### PR DESCRIPTION
## Summary

I have had vim installed but could not open it in powershell since the created alias pointed to itself.

## Type Of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## Testing

Manually tested on my machine.

## Checklist

- [x] I tested my changes locally.
- [x] I updated docs if needed.
- [x] My changes are focused and do not include unrelated edits.
